### PR TITLE
[WIP] 11.0 mig base geoengine widgets

### DIFF
--- a/base_geoengine/static/src/js/fields/geoengine_field_registry.js
+++ b/base_geoengine/static/src/js/fields/geoengine_field_registry.js
@@ -1,0 +1,22 @@
+/*---------------------------------------------------------
+ * Odoo base_geoengine
+ * Author Yannick Vaucher Copyright 2018 Camptocamp SA
+ * License in __manifest__.py at root level of the module
+ *---------------------------------------------------------
+*/
+
+odoo.define('base_geoengine.geoengine_field_registry', function (require) {
+
+var registry = require('web.field_registry');
+var geoengine_widgets = require('base_geoengine.geoengine_widgets');
+
+// Special fields
+registry
+    .add('geo_edit_map', geoengine_widgets.FieldGeoEngineEditMap)
+    .add('geo_edit_map_readonly', geoengine_widgets.FieldGeoEngineEditMapReadonly)
+    .add('geo_point_xy', geoengine_widgets.FieldGeoPointXY)
+    .add('geo_point_xy', geoengine_widgets.FieldGeoPointXYReadonly)
+    .add('geo_rect', geoengine_widgets.FieldGeoRect)
+    .add('geo_rect', geoengine_widgets.FieldGeoRectReadonly);
+
+});

--- a/base_geoengine/static/src/js/widgets/geoengine_widgets.js
+++ b/base_geoengine/static/src/js/widgets/geoengine_widgets.js
@@ -56,7 +56,7 @@ var FieldGeoEngineEditMap = AbstractField.extend(geoengine_common.GeoengineMixin
         });
     },
 
-    create_layers: function(self, field_infos) {
+    create_layersAbstractFieldself, field_infos) {
         this.vector_layer = this.create_vector_layer();
         this.raster_layers = this.createBackgroundLayers([field_infos.edit_raster]);
         this.raster_layers[0].isBaseLayer = true;
@@ -78,7 +78,7 @@ var FieldGeoEngineEditMap = AbstractField.extend(geoengine_common.GeoengineMixin
         if (this.map) {
             return;
         }
-        this.view.on("change:actual_mode", this, this.on_mode_change);
+        this.view.on("change:actual_mode", this, this.on_mode_change); // TODO: find way to fix that
         var self = this;
         // add a listener on parent tab if it exists in order to refresh geoengine view
         // we need to trigger it on DOM update for changes from view to edit mode
@@ -505,14 +505,6 @@ var FieldGeoRectReadonly = FieldGeoRect.extend({
         this.invalid = false;
     }
 });
-
-core.form_widget_registry
-    .add('geo_edit_map', FieldGeoEngineEditMap)
-    .add('geo_edit_map_readonly', FieldGeoEngineEditMapReadonly)
-    .add('geo_point_xy', FieldGeoPointXY)
-    .add('geo_point_xy', FieldGeoPointXYReadonly)
-    .add('geo_rect', FieldGeoRect)
-    .add('geo_rect', FieldGeoRectReadonly);
 
 return {
     FieldGeoEngineEditMap: FieldGeoEngineEditMap,

--- a/base_geoengine/views/base_geoengine_view.xml
+++ b/base_geoengine/views/base_geoengine_view.xml
@@ -21,7 +21,9 @@
             <script type="text/javascript"
 		    src="/base_geoengine/static/src/js/views/geoengine/geoengine_view.js"/>
             <script type="text/javascript"
-                    src="/base_geoengine/static/src/js/views/geoengine_widgets.js"/>
+                    src="/base_geoengine/static/src/js/widgets/geoengine_widgets.js"/>
+            <script type="text/javascript"
+                    src="/base_geoengine/static/src/js/fields/geoengine_field_registry.js"/>
 
             <script type="text/javascript"
                     src="/base_geoengine/static/src/js/views/view_registry.js"/>


### PR DESCRIPTION
### widgets worked:
- [ ] geo_edit_map
- [ ] geo_point_xy
- [ ] geo_rect

### :warning:  actual error / may be location in old js : 
*  `TypeError: this.setupFocus is not a function` / [10.0/addons/web/static/src/js/views/form_common.js#L446](https://github.com/odoo/odoo/blob/10.0/addons/web/static/src/js/views/form_common.js#L446)
* `TypeError: this.view is undefined`  / [10.0/addons/web/static/src/js/views/form_widgets.js#L311](https://github.com/odoo/odoo/blob/10.0/addons/web/static/src/js/views/form_widgets.js#L311)

------

* Missing widget:  geo_edit_map  for field ...
* Missing widget:  geo_rect  for field ...
* Missing widget:  geo_point_xy  for field ...

-----

### To test may be with `base_geoengine_demo` module in same geospatial repository
actual PR : [https://github.com/OCA/geospatial/pull/177](https://github.com/OCA/geospatial/pull/177)

careful off this view.widget -> [https://github.com/OCA/geospatial/pull/177/files#diff-764256337b75cb0d6c27211022ee19a8R14](https://github.com/OCA/geospatial/pull/177/files#diff-764256337b75cb0d6c27211022ee19a8R14)
