### PR TITLE
Use EPSG:3857 instead of EPSG:900913

### DIFF
--- a/base_geoengine/fields.py
+++ b/base_geoengine/fields.py
@@ -37,7 +37,7 @@ class GeoField(fields.Field):
 
     _slots = {
         'dim': 2,
-        'srid': 900913,
+        'srid': 3857,
         'gist_index': True,
         'manual': True,
     }

--- a/base_geoengine/geo_model.py
+++ b/base_geoengine/geo_model.py
@@ -65,7 +65,7 @@ class GeoModel(models.AbstractModel):
                     if not field.dim:
                         geo_type['dim'] = 2
                     if not field.srid:
-                        geo_type['srid'] = 900913
+                        geo_type['srid'] = 3857
                 res[f_name]['geo_type'] = geo_type
         return res
 

--- a/base_geoengine/geo_view/ir_view.py
+++ b/base_geoengine/geo_view/ir_view.py
@@ -29,7 +29,7 @@ class IrUIView(models.Model):
     vector_layer_ids = fields.One2many(
         'geoengine.vector.layer', 'view_id', 'Vector layers', required=True)
 
-    projection = fields.Char(default="EPSG:900913", required=True)
+    projection = fields.Char(default="EPSG:3857", required=True)
     default_extent = fields.Char(
         'Default map extent', size=128,
         default='-123164.85222423, 5574694.9538936, 1578017.6490538,'

--- a/test_base_geoengine/tests/data.py
+++ b/test_base_geoengine/tests/data.py
@@ -108,7 +108,7 @@ GEO_VIEW = {
         "default_extent": "-123164.85222423, 5574694.9538936,"
                           " 1578017.6490538, 6186191.1800898",
         "default_zoom": 0,
-        "projection": "EPSG:900913",
+        "projection": "EPSG:3857",
         "restricted_extent": False
     },
     "model": "test.dummy",
@@ -121,7 +121,7 @@ FORM_VIEW = {
         "geo_multipolygon": {
             "geo_type": {
                 "dim": 2,
-                "srid": 900913,
+                "srid": 3857,
                 "type": "geo_multi_polygon"
             },
             "required": False,
@@ -141,5 +141,5 @@ EXPECTED_GEO_COLUMN_MULTIPOLYGON = {
     'default_extent':
         '-123164.85222423, 5574694.9538936, 1578017.6490538, 6186191.1800898',
     'geo_type': 'MULTIPOLYGON',
-    'srid': 900913
+    'srid': 3857
 }


### PR DESCRIPTION
EPSG:3857 is the official name for the spherical pseudo-mercator coordinate system.
The unofficial 900913 code is deprecated and should not be used as the default anymore.