### PR TITLE
Remove server_resolutions field in WMTS options

### DIFF
--- a/base_geoengine/geo_view/geo_raster_layer.py
+++ b/base_geoengine/geo_view/geo_raster_layer.py
@@ -43,9 +43,6 @@ class GeoRasterLayer(models.Model):
     units = fields.Char(help="eg. m")
     resolutions = fields.Char("resolutions")
     max_extent = fields.Char("max_extent")
-    server_resolutions = fields.Char(
-        "resolutions",
-        help="List of dimensions separated by ',' eg. 50, 20, 10")
     dimensions = fields.Char(
         "dimensions",
         help="List of dimensions separated by ','")

--- a/base_geoengine/geo_view/geo_raster_layer_view.xml
+++ b/base_geoengine/geo_view/geo_raster_layer_view.xml
@@ -26,7 +26,6 @@
                   <field name="units"/>
                   <field name="resolutions"/>
                   <field name="max_extent"/>
-                  <field name="server_resolutions"/>
                   <field name="dimensions"/>
                   <field name="params"/>
                 </group>

--- a/base_geoengine/static/src/js/geoengine_common.js
+++ b/base_geoengine/static/src/js/geoengine_common.js
@@ -95,11 +95,6 @@ odoo.define('base_geoengine.geoengine_common', function (require) {
                         layer_opt.extent = extent;
                         tilegrid_opt.extent = extent;
                     }
-                    // FIXME deprecated?
-                    // if (l.server_resolutions) {
-                    //     opt.serverResolutions =
-                    //         l.server_resolutions.split(',').map(Number);
-                    // }
                     if (l.params) {
                         // FIXME still used?
                         //source_opt.dimensions = l.dimensions.split(',');


### PR DESCRIPTION
Deprecated in OpenLayers >3